### PR TITLE
Make it easier to have multiple healthCheck scripts for a single service

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -97,6 +97,6 @@ task :v => [:verbose_test]
 desc "Verbose test"
 task :verbose_test => [:apgar_probe] do
   sh %{ echo ziggy > tmp/status }
-  system("./apgar-probe --debug 50 --document-root tmp --healthcheck-tree fixtures/004-multiple-failing")
+  system("./apgar-probe --debug 50 --document-root tmp --healthcheck-tree fixtures/005-suffix-passes")
   system("cat tmp/status")
 end

--- a/apgar-probe.go
+++ b/apgar-probe.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 )
@@ -83,7 +84,7 @@ func runHealthCheck(wg *sync.WaitGroup, path string) {
 	var waitStatus syscall.WaitStatus
 	if err := cmd.Run(); err != nil {
 		printError(err)
-		// Did the command fail because of an unsuccessful exit code
+		// Did the command fail because of an unsuccessful exit code?
 		if exitError, ok := err.(*exec.ExitError); ok {
 			waitStatus = exitError.Sys().(syscall.WaitStatus)
 			fmt.Printf("%v: %d\n", path, waitStatus.ExitStatus())
@@ -104,7 +105,7 @@ func (w *Walker) visit(path string, fi os.FileInfo, err error) error {
 		fmt.Printf("w.waitGroup: %v\n", w.waitGroup)
 		fmt.Printf("&w.waitGroup: %s\n", &w.waitGroup)
 	}
-	if filepath.Base(path) == w.healthCheckName {
+	if strings.HasSuffix(filepath.Base(path), w.healthCheckName) {
 		w.waitGroup.Add(1)
 		if debug > 0 {
 			fmt.Printf("\n\npost add\n")
@@ -152,7 +153,7 @@ func debugDump() {
 func main() {
 	flag.IntVar(&debug, "debug", 0, "Debug level")
 	flag.StringVar(&documentRoot, "document-root", "/var/lib/apgar", "Document root")
-	flag.StringVar(&healthCheckName, "healthcheck-name", "healthCheck", "health check script name")
+	flag.StringVar(&healthCheckName, "healthcheck-name", "healthCheck", "health check script suffix")
 	flag.StringVar(&healthCheckTree, "healthcheck-tree", "/var/lib/apgar", "Directory tree to search for health checks")
 
 	flag.Parse()

--- a/apgar_tests.rb
+++ b/apgar_tests.rb
@@ -50,4 +50,18 @@ class TestApgarProbe < MiniTest::Test
     assert_equal "OK\n", File.open(STATUS_FILE) { |file| file.read }
   end
 
+  def test_suffix_passing
+    run = `./apgar-probe --document-root tmp --healthcheck-tree fixtures/005-suffix-passes`
+    exitcode = $?.to_i
+    assert_equal true, (exitcode == 0)
+    assert_equal "OK\n", File.open(STATUS_FILE) { |file| file.read }
+  end
+
+  def test_suffix_failing
+    run = `./apgar-probe --document-root tmp --healthcheck-tree fixtures/006-suffix-fails`
+    exitcode = $?.to_i
+    assert_equal false, (exitcode == 0)
+    assert_equal "UNHEALTHY\n", File.open(STATUS_FILE) { |file| file.read }
+  end
+
 end

--- a/fixtures/005-suffix-passes/suffixtest.healthCheck
+++ b/fixtures/005-suffix-passes/suffixtest.healthCheck
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Passing healthCheck script
+#
+# Copyright 2016, DAQRI, LLC.
+
+set -o pipefail
+
+randsleep 5
+echo "OK"
+exit 0

--- a/fixtures/006-suffix-fails/failing.healthCheck
+++ b/fixtures/006-suffix-fails/failing.healthCheck
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Failing healthCheck script
+#
+# Copyright 2016, DAQRI, LLC.
+
+set -o pipefail
+
+echo "NOT OK"
+exit 1


### PR DESCRIPTION
Specify a suffix for the checks we want to run instead of forcing them to all use the same name. We want to be able to use meaningful names for the healthChecks and keep them each checking a single thing.
