### PR TITLE
change healthy response so it can pass aws load balance health check

### DIFF
--- a/apgar-probe.go
+++ b/apgar-probe.go
@@ -42,6 +42,7 @@ var documentRoot string
 var healthCheckName string
 var healthCheckTree string
 var healthy bool
+var healthyResponse string
 
 type Walker struct {
 	documentRoot    string
@@ -129,7 +130,7 @@ func write_health_status(path string, healthy bool) error {
 	healthFile, err := os.Create(healthFilePath)
 	errorCheck(err)
 	if healthy {
-		statusString = "OK\n"
+		statusString = healthyResponse
 	} else {
 		statusString = "UNHEALTHY\n"
 	}
@@ -155,6 +156,7 @@ func main() {
 	flag.StringVar(&documentRoot, "document-root", "/var/lib/apgar", "Document root")
 	flag.StringVar(&healthCheckName, "healthcheck-name", "healthCheck", "health check script suffix")
 	flag.StringVar(&healthCheckTree, "healthcheck-tree", "/var/lib/apgar", "Directory tree to search for health checks")
+	flag.StringVar(&healthyResponse, "healthy-response", "200 OK\n", "The response string if status is healthy")
 
 	flag.Parse()
 

--- a/apgar_tests.rb
+++ b/apgar_tests.rb
@@ -33,7 +33,7 @@ class TestApgarProbe < MiniTest::Test
     run = `./apgar-probe --document-root tmp --healthcheck-tree fixtures/003-multiple-passing`
     exitcode = $?.to_i
     assert_equal true, (exitcode == 0)
-    assert_equal "OK\n", File.open(STATUS_FILE) { |file| file.read }
+    assert_equal "200 OK\n", File.open(STATUS_FILE) { |file| file.read }
   end
 
   def test_single_failing
@@ -47,14 +47,14 @@ class TestApgarProbe < MiniTest::Test
     run = `./apgar-probe --document-root tmp --healthcheck-tree fixtures/001-single-passing`
     exitcode = $?.to_i
     assert_equal true, (exitcode == 0)
-    assert_equal "OK\n", File.open(STATUS_FILE) { |file| file.read }
+    assert_equal "200 OK\n", File.open(STATUS_FILE) { |file| file.read }
   end
 
   def test_suffix_passing
     run = `./apgar-probe --document-root tmp --healthcheck-tree fixtures/005-suffix-passes`
     exitcode = $?.to_i
     assert_equal true, (exitcode == 0)
-    assert_equal "OK\n", File.open(STATUS_FILE) { |file| file.read }
+    assert_equal "200 OK\n", File.open(STATUS_FILE) { |file| file.read }
   end
 
   def test_suffix_failing


### PR DESCRIPTION
@unixorn 

I have never used go before, not sure if I'm writing the right code here. What I'm trying to do is adding an option for passing any response you like, and set the default one to be '200 OK' so aws load balance health check can recognize it.
