### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,29 +4,47 @@ GEM
     ansi (1.5.0)
     arr-pm (0.0.10)
       cabin (> 0)
-    backports (3.6.8)
-    builder (3.2.2)
-    cabin (0.8.1)
-    childprocess (0.5.9)
+    backports (3.17.2)
+    builder (3.2.4)
+    cabin (0.9.0)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    clamp (0.6.5)
-    ffi (1.9.10)
-    fpm (1.4.0)
+    clamp (1.0.1)
+    dotenv (2.7.5)
+    ffi (1.13.1)
+    fpm (1.11.0)
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
-      childprocess
-      clamp (~> 0.6)
+      childprocess (= 0.9.0)
+      clamp (~> 1.0.0)
       ffi
-      json (>= 1.7.7)
-    json (1.8.3)
-    minitest (5.8.4)
-    minitest-reporters (1.1.8)
+      json (>= 1.7.7, < 2.0)
+      pleaserun (~> 0.0.29)
+      ruby-xz (~> 0.2.3)
+      stud
+    insist (1.0.0)
+    io-like (0.3.1)
+    json (1.8.6)
+    minitest (5.14.1)
+    minitest-reporters (1.4.2)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    ruby-progressbar (1.7.5)
+    mustache (0.99.8)
+    pleaserun (0.0.31)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    ruby-progressbar (1.10.1)
+    ruby-xz (0.2.3)
+      ffi (~> 1.9)
+      io-like (~> 0.3)
+    stud (0.0.23)
 
 PLATFORMS
   ruby
@@ -36,4 +54,4 @@ DEPENDENCIES
   minitest-reporters
 
 BUNDLED WITH
-   1.11.2
+   2.1.4


### PR DESCRIPTION
Get up to date so we have security updates. Didn't realize it had been four years since I last updated `Gemfile.lock`.